### PR TITLE
Did you mean

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -218,7 +218,7 @@ public class Options {
     public static final Option<String> CLI_BACKUP_EXTENSION = string(CLI, "cli.backup.extension", "Backup extension for in-place ARGV files. Same as -i.");
     public static final Option<ProfilingMode> CLI_PROFILING_MODE = enumeration(CLI, "cli.profiling.mode", ProfilingMode.class, ProfilingMode.OFF, "Enable instrumented profiling modes.");
     public static final Option<Boolean> CLI_RUBYGEMS_ENABLE = bool(CLI, "cli.rubygems.enable", true, "Enable/disable RubyGems.");
-    public static final Option<Boolean> CLI_DID_YOU_MEAN_ENABLE = bool(CLI, "cli.did_you_mean.enable", false, "Enable/disable did_you_mean.");
+    public static final Option<Boolean> CLI_DID_YOU_MEAN_ENABLE = bool(CLI, "cli.did_you_mean.enable", true, "Enable/disable did_you_mean.");
     public static final Option<Boolean> CLI_RUBYOPT_ENABLE = bool(CLI, "cli.rubyopt.enable", true, "Enable/disable RUBYOPT processing at start.");
     public static final Option<Boolean> CLI_STRIP_HEADER = bool(CLI, "cli.strip.header", false, "Strip text before shebang in script. Same as -x.");
     public static final Option<Boolean> CLI_LOAD_GEMFILE = bool(CLI, "cli.load.gemfile", false, "Load a bundler Gemfile in cwd before running. Same as -G.");

--- a/core/src/main/ruby/jruby/kernel/gem_prelude.rb
+++ b/core/src/main/ruby/jruby/kernel/gem_prelude.rb
@@ -8,6 +8,7 @@ if defined?(Gem)
     begin
       gem 'did_you_mean'
       require 'did_you_mean'
+      Gem.clear_paths
     rescue Gem::LoadError, LoadError
     end if defined?(DidYouMean)
   end

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -22,7 +22,7 @@ default_gems =
    ImportedGem.new( 'jar-dependencies', '${jar-dependencies.version}' ),
    ImportedGem.new( 'racc', '${racc.version}'),
    ImportedGem.new( 'net-telnet', '0.1.1'),
-   #ImportedGem.new( 'did_you_mean', '1.0.1'),
+   ImportedGem.new( 'did_you_mean', '1.0.1'),
   ]
 
 project 'JRuby Lib Setup' do

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -187,6 +187,19 @@ DO NOT MODIFIY - GENERATED CODE
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>did_you_mean</artifactId>
+      <version>1.0.1</version>
+      <type>gem</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>jar-dependencies</artifactId>
+          <groupId>rubygems</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>


### PR DESCRIPTION
This enables did_you_mean and installs it during the build. Fixes #3480.

@mkristian I could not figure out how to make this work without being a default gem. We do not have any logic to preinstall gems that aren't default, do we?

This also includes the `Gem.clear_paths` hack to address too-early booting of RubyGems in embedded scenarios.