### PR TITLE
Fiddle::Function fixes

### DIFF
--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -163,8 +163,6 @@ module Fiddle
         elsif ptr.is_a?(FFI::Pointer)
           Pointer.new(ptr)
         else
-          p value
-          p ptr
           raise DLError.new('to_ptr should return a Fiddle::Pointer object')
         end
 

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -88,16 +88,22 @@ module Fiddle
     end
 
     def call(*args)
-      native_args = args.zip(@args).map{ |arg,type| make_native(arg, type) }
+      pointer_args = args.zip(@args).map{ |arg,type| make_pointer(arg, type) }
+      native_args = pointer_args.zip(@args).map{ |ptr,type| make_native(ptr, type) }
       ret = self.__ffi_call__(*native_args)
-      make_native(ret, @return_type)
+      make_pointer(ret, @return_type)
     end
 
     private
 
-    def make_native(arg, type)
+    def make_pointer(arg, type)
       return arg if type != TYPE_VOIDP
       Pointer[arg]
+    end
+
+    def make_native(ptr, type)
+      return ptr if type != TYPE_VOIDP
+      ptr.ffi_ptr
     end
   end
 
@@ -211,10 +217,6 @@ module Fiddle
 
     def null?
       @ffi_ptr.null?
-    end
-
-    def to_ptr
-      @ffi_ptr
     end
 
     def size

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -84,11 +84,21 @@ module Fiddle
         FFI::Pointer.new(ptr.to_i),
         :convention => @abi
       )
-      @function.attach(self, "call")
+      @function.attach(self, "__ffi_call__")
     end
 
-    # stubbed; should be overwritten by initialize's #attach call above
-    def call(*args); end
+    def call(*args)
+      native_args = args.zip(@args).map{ |arg,type| make_native(arg, type) }
+      ret = self.__ffi_call__(*native_args)
+      make_native(ret, @return_type)
+    end
+
+    private
+
+    def make_native(arg, type)
+      return arg if type != TYPE_VOIDP
+      Pointer[arg]
+    end
   end
 
   class Closure

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -150,11 +150,18 @@ module Fiddle
         cptr.ffi_ptr.put_string(0, value)
         cptr
 
+      elsif value.is_a?(FFI::Pointer)
+        Pointer.new(value)
+
       elsif value.respond_to?(:to_ptr)
         ptr = value.to_ptr
         if ptr.is_a?(Pointer)
           ptr
+        elsif ptr.is_a?(FFI::Pointer)
+          Pointer.new(ptr)
         else
+          p value
+          p ptr
           raise DLError.new('to_ptr should return a Fiddle::Pointer object')
         end
 

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -310,12 +310,14 @@ module Fiddle
     def ptr
       Pointer.new(ffi_ptr.get_pointer(0))
     end
+    alias +@ ptr
 
     def ref
       cptr = Pointer.malloc(FFI::Type::POINTER.size)
       cptr.ffi_ptr.put_pointer(0, ffi_ptr)
       cptr
     end
+    alias -@ ref
   end
 
   NULL = Pointer.new(0, 0, 0)

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -144,6 +144,9 @@ module Fiddle
     end
 
     def self.to_ptr(value)
+      if value.is_a?(IO)
+        raise "Converting IO to Pointer is not supported yet"
+      end
       if value.is_a?(String)
         cptr = Pointer.malloc(value.bytesize + 1)
         size = value.bytesize + 1


### PR DESCRIPTION
Fixes jruby/jruby#4518

Convert pointer-type arguments to actual pointers when calling a Fiddle::Function.

Also, I added a clause to raise when attempting to pass an IO object to a Fiddle::Function. This is because, currently, this action causes a Segfault. Raising merely avoids this scenario for now. We will have to rectify this issue in the future, but currently this isn't causing any loss in functionality as far as I can tell.

I also implemented `Fiddle::Pointer#-@` and `Fiddle::Pointer#+@` because I noticed they were missing.