### PR TITLE
Fix: using strings as out arguments in Fiddle

### DIFF
--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -88,8 +88,7 @@ module Fiddle
     end
 
     def call(*args)
-      pointer_args = args.zip(@args).map{ |arg,type| make_pointer(arg, type) }
-      native_args = pointer_args.zip(@args).map{ |ptr,type| make_native(ptr, type) }
+      native_args = args.zip(@args).map{ |arg,type| make_native(make_pointer(arg, type)) }
       ret = self.__ffi_call__(*native_args)
       make_pointer(ret, @return_type)
     end
@@ -98,11 +97,13 @@ module Fiddle
 
     def make_pointer(arg, type)
       return arg if type != TYPE_VOIDP
+      return arg if arg.is_a?(String)
       Pointer[arg]
     end
 
     def make_native(ptr, type)
       return ptr if type != TYPE_VOIDP
+      return ptr if ptr.is_a?(String)
       ptr.ffi_ptr
     end
   end

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -163,8 +163,6 @@ module Fiddle
         elsif ptr.is_a?(FFI::Pointer)
           Pointer.new(ptr)
         else
-          p value
-          p ptr
           raise DLError.new('to_ptr should return a Fiddle::Pointer object')
         end
 

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -88,16 +88,22 @@ module Fiddle
     end
 
     def call(*args)
-      native_args = args.zip(@args).map{ |arg,type| make_native(arg, type) }
+      pointer_args = args.zip(@args).map{ |arg,type| make_pointer(arg, type) }
+      native_args = pointer_args.zip(@args).map{ |ptr,type| make_native(ptr, type) }
       ret = self.__ffi_call__(*native_args)
-      make_native(ret, @return_type)
+      make_pointer(ret, @return_type)
     end
 
     private
 
-    def make_native(arg, type)
+    def make_pointer(arg, type)
       return arg if type != TYPE_VOIDP
       Pointer[arg]
+    end
+
+    def make_native(ptr, type)
+      return ptr if type != TYPE_VOIDP
+      ptr.ffi_ptr
     end
   end
 
@@ -211,10 +217,6 @@ module Fiddle
 
     def null?
       @ffi_ptr.null?
-    end
-
-    def to_ptr
-      @ffi_ptr
     end
 
     def size

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -84,11 +84,21 @@ module Fiddle
         FFI::Pointer.new(ptr.to_i),
         :convention => @abi
       )
-      @function.attach(self, "call")
+      @function.attach(self, "__ffi_call__")
     end
 
-    # stubbed; should be overwritten by initialize's #attach call above
-    def call(*args); end
+    def call(*args)
+      native_args = args.zip(@args).map{ |arg,type| make_native(arg, type) }
+      ret = self.__ffi_call__(*native_args)
+      make_native(ret, @return_type)
+    end
+
+    private
+
+    def make_native(arg, type)
+      return arg if type != TYPE_VOIDP
+      Pointer[arg]
+    end
   end
 
   class Closure

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -150,11 +150,18 @@ module Fiddle
         cptr.ffi_ptr.put_string(0, value)
         cptr
 
+      elsif value.is_a?(FFI::Pointer)
+        Pointer.new(value)
+
       elsif value.respond_to?(:to_ptr)
         ptr = value.to_ptr
         if ptr.is_a?(Pointer)
           ptr
+        elsif ptr.is_a?(FFI::Pointer)
+          Pointer.new(ptr)
         else
+          p value
+          p ptr
           raise DLError.new('to_ptr should return a Fiddle::Pointer object')
         end
 

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -310,12 +310,14 @@ module Fiddle
     def ptr
       Pointer.new(ffi_ptr.get_pointer(0))
     end
+    alias +@ ptr
 
     def ref
       cptr = Pointer.malloc(FFI::Type::POINTER.size)
       cptr.ffi_ptr.put_pointer(0, ffi_ptr)
       cptr
     end
+    alias -@ ref
   end
 
   NULL = Pointer.new(0, 0, 0)

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -144,6 +144,9 @@ module Fiddle
     end
 
     def self.to_ptr(value)
+      if value.is_a?(IO)
+        raise "Converting IO to Pointer is not supported yet"
+      end
       if value.is_a?(String)
         cptr = Pointer.malloc(value.bytesize + 1)
         size = value.bytesize + 1


### PR DESCRIPTION
Previously, I was creating a new pointer for every VOIDP argument passed in to a Fiddle::Function. Incidentally, this reallocates a copy of any Strings passed in as those variables, defeating the point of out arguments. Since FFI does some magic when Strings are passed in as out arguments, I opted to just leave String arguments as is and let FFI do it's thing.