### PR TITLE
Fiddle Fixes for Windows

### DIFF
--- a/lib/ruby/stdlib/ffi/libc.rb
+++ b/lib/ruby/stdlib/ffi/libc.rb
@@ -11,30 +11,34 @@ module FFI
     # time.h
     typedef :long, :clock_t
 
-    ffi_lib [FFI::CURRENT_PROCESS, 'c']
+    ffi_lib FFI::Library::LIBC
 
     # The NULL constant
     NULL = nil
 
     # errno.h
-    attach_variable :sys_errlist, :pointer
-    attach_variable :sys_nerr, :int
-    attach_variable :errno, :int
+    unless FFI::Platform.windows?
+      attach_variable :sys_errlist, :pointer
+      attach_variable :sys_nerr, :int
+      attach_variable :errno, :int
+    end
 
     def self.raise_error(error=self.errno)
       raise(strerror(error))
     end
 
     # unistd.h
-    attach_function :brk, [:pointer], :int
-    attach_function :sbrk, [:pointer], :pointer
-    attach_function :getpid, [], :pid_t
-    attach_function :getppid, [], :pid_t
-    attach_function :getuid, [], :uid_t
-    attach_function :geteuid, [], :uid_t
-    attach_function :getgid, [], :gid_t
-    attach_function :getegid, [], :gid_t
-    attach_function :alarm, [:uint], :uint
+    unless FFI::Platform.windows?
+      attach_function :brk, [:pointer], :int
+      attach_function :sbrk, [:pointer], :pointer
+      attach_function :getpid, [], :pid_t
+      attach_function :getppid, [], :pid_t
+      attach_function :getuid, [], :uid_t
+      attach_function :geteuid, [], :uid_t
+      attach_function :getgid, [], :gid_t
+      attach_function :getegid, [], :gid_t
+      attach_function :alarm, [:uint], :uint
+    end
 
     # stdlib.h
     attach_function :calloc, [:size_t, :size_t], :pointer
@@ -42,8 +46,10 @@ module FFI
     FREE = attach_function :free, [:pointer], :void
     attach_function :realloc, [:pointer, :size_t], :pointer
     attach_function :getenv, [:string], :string
-    attach_function :putenv, [:string], :int
-    attach_function :unsetenv, [:string], :int
+    unless FFI::Platform.windows?
+      attach_function :putenv, [:string], :int
+      attach_function :unsetenv, [:string], :int
+    end
 
     begin
       attach_function :clearenv, [], :int
@@ -56,15 +62,19 @@ module FFI
     attach_function :time, [:pointer], :time_t
 
     # sys/time.h
-    attach_function :gettimeofday, [:pointer, :pointer], :int
-    attach_function :settimeofday, [:pointer, :pointer], :int
+    unless FFI::Platform.windows?
+      attach_function :gettimeofday, [:pointer, :pointer], :int
+      attach_function :settimeofday, [:pointer, :pointer], :int
+    end
 
     # sys/mman.h
-    attach_function :mmap, [:pointer, :size_t, :int, :int, :int, :off_t], :pointer
-    attach_function :munmap, [:pointer, :size_t], :int
+    unless FFI::Platform.windows?
+      attach_function :mmap, [:pointer, :size_t, :int, :int, :int, :off_t], :pointer
+      attach_function :munmap, [:pointer, :size_t], :int
+    end
 
     # string.h
-    attach_function :bzero, [:pointer, :size_t], :void
+    attach_function :bzero, [:pointer, :size_t], :void unless FFI::Platform.windows?
     attach_function :memset, [:pointer, :int, :size_t], :pointer
     attach_function :memcpy, [:buffer_out, :buffer_in, :size_t], :pointer
     attach_function :memcmp, [:buffer_in, :buffer_in, :size_t], :int
@@ -81,8 +91,10 @@ module FFI
     attach_function :strcmp, [:buffer_in, :buffer_in], :int
     attach_function :strncmp, [:buffer_in, :buffer_in, :size_t], :int
     attach_function :strlen, [:buffer_in], :size_t
-    attach_function :index, [:buffer_in, :int], :pointer
-    attach_function :rindex, [:buffer_in, :int], :pointer
+    unless FFI::Platform.windows?
+      attach_function :index, [:buffer_in, :int], :pointer
+      attach_function :rindex, [:buffer_in, :int], :pointer
+    end
     attach_function :strchr, [:buffer_in, :int], :pointer
     attach_function :strrchr, [:buffer_in, :int], :pointer
     attach_function :strstr, [:buffer_in, :string], :pointer
@@ -97,7 +109,7 @@ module FFI
     end
 
     attach_function :fopen, [:string, :string], :FILE
-    attach_function :fdopen, [:int, :string], :FILE
+    attach_function :fdopen, [:int, :string], :FILE unless FFI::Platform.windows?
     attach_function :freopen, [:string, :string, :FILE], :FILE
     attach_function :fseek, [:FILE, :long, :int], :int
     attach_function :ftell, [:FILE], :long
@@ -113,7 +125,7 @@ module FFI
     attach_function :clearerr, [:FILE], :void
     attach_function :feof, [:FILE], :int
     attach_function :ferror, [:FILE], :int
-    attach_function :fileno, [:FILE], :int
+    attach_function :fileno, [:FILE], :int unless FFI::Platform.windows?
     attach_function :perror, [:string], :void
 
     attach_function :getc, [:FILE], :int
@@ -126,12 +138,14 @@ module FFI
     attach_function :puts, [:string], :int
 
     # netdb.h
-    attach_function :getnameinfo, [
-      :pointer,
-      :socklen_t, :pointer,
-      :socklen_t, :pointer,
-      :socklen_t, :int
-    ], :int
+    unless FFI::Platform.windows?
+      attach_function :getnameinfo, [
+        :pointer,
+        :socklen_t, :pointer,
+        :socklen_t, :pointer,
+        :socklen_t, :int
+      ], :int
+    end
 
     NI_MAXHOST = 1024
     NI_MAXSERV = 32
@@ -143,8 +157,10 @@ module FFI
     NI_DGRAM       = 16      # Look up UDP service rather than TCP.
 
     # ifaddrs.h
-    attach_function :getifaddrs, [:pointer], :int
-    attach_function :freeifaddrs, [:pointer], :void
+    unless FFI::Platform.windows?
+      attach_function :getifaddrs, [:pointer], :int
+      attach_function :freeifaddrs, [:pointer], :void
+    end
 
     #
     # Enumerates over the Interface Addresses.
@@ -189,7 +205,7 @@ module FFI
     RUSAGE_CHILDREN = -1
     RUSAGE_THREAD = 1 # Linux/glibc only
 
-    attach_function :getrusage, [:int, :pointer], :int
+    attach_function :getrusage, [:int, :pointer], :int unless FFI::Platform.windows?
 
     #
     # Gets the RUsage for the user.

--- a/lib/ruby/stdlib/ffi/libc.rb
+++ b/lib/ruby/stdlib/ffi/libc.rb
@@ -51,10 +51,12 @@ module FFI
       attach_function :unsetenv, [:string], :int
     end
 
-    begin
-      attach_function :clearenv, [], :int
-    rescue FFI::NotFoundError
-      # clearenv is not available on OSX
+    unless FFI::Platform.windows?
+      begin
+        attach_function :clearenv, [], :int
+      rescue FFI::NotFoundError
+        # clearenv is not available on OSX
+      end
     end
 
     # time.h
@@ -80,10 +82,12 @@ module FFI
     attach_function :memcmp, [:buffer_in, :buffer_in, :size_t], :int
     attach_function :memchr, [:buffer_in, :int, :size_t], :pointer
 
-    begin
-      attach_function :memrchr, [:buffer_in, :int, :size_t], :pointer
-    rescue FFI::NotFoundError
-      # memrchr is not available on OSX
+    unless FFI::Platform.windows?
+      begin
+        attach_function :memrchr, [:buffer_in, :int, :size_t], :pointer
+      rescue FFI::NotFoundError
+        # memrchr is not available on OSX
+      end
     end
 
     attach_function :strcpy, [:buffer_out, :string], :pointer
@@ -100,12 +104,14 @@ module FFI
     attach_function :strstr, [:buffer_in, :string], :pointer
     attach_function :strerror, [:int], :string
 
-    begin
-      attach_variable :stdin, :pointer
-      attach_variable :stdout, :pointer
-      attach_variable :stderr, :pointer
-    rescue FFI::NotFoundError
-      # stdin, stdout, stderr are not available on OSX
+    unless FFI::Platform.windows?
+      begin
+        attach_variable :stdin, :pointer
+        attach_variable :stdout, :pointer
+        attach_variable :stderr, :pointer
+      rescue FFI::NotFoundError
+        # stdin, stdout, stderr are not available on OSX
+      end
     end
 
     attach_function :fopen, [:string, :string], :FILE


### PR DESCRIPTION
Fixes issues with LibC not loading on Windows. This is because a lot of LibC functions are not implemented on Windows. It also appears that some of the functions were even removed in later versions of windows.